### PR TITLE
feat(view): surface classifier reasoning instead of an 'AI slop' verdict

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -34,6 +34,8 @@ model Post {
   thumbnailUrl String
   votesCount   Int         @default(0)
   hasAi        Boolean     @default(false)
+  /// the classifier's reasoning for the hasAi verdict (which AI terms it found); null for rows analyzed before this field existed
+  reasoning    String?
   media        Json?       @default("[]")
   /// if the post is deleted, it means it was deleted by the user or product hunt team
   deleted      Boolean     @default(false)

--- a/apps/web/src/app/api/ingest-posts/route.ts
+++ b/apps/web/src/app/api/ingest-posts/route.ts
@@ -41,9 +41,12 @@ export async function GET(request: NextRequest) {
   }));
   const aiAnalysisResults = await analyzePosts(postsToAnalyze);
 
-  // Create a map of post IDs to their AI analysis results
+  // Create a map of post IDs to their AI analysis result (isAiRelated + reasoning)
   const postAiResults = new Map(
-    posts.map((post) => [post.id, aiAnalysisResults.get(post.id) ?? false]),
+    posts.map((post) => [
+      post.id,
+      aiAnalysisResults.get(post.id) ?? { isAiRelated: false, reasoning: null },
+    ]),
   );
 
   const existingPostsList = await db.post.findMany({
@@ -88,7 +91,8 @@ export async function GET(request: NextRequest) {
           tagline: post.tagline,
           url: post.url,
           media: post.media,
-          hasAi: postAiResults.get(post.id) ?? false,
+          hasAi: postAiResults.get(post.id)?.isAiRelated ?? false,
+          reasoning: postAiResults.get(post.id)?.reasoning ?? null,
           thumbnailUrl: post.thumbnail.url,
           createdAt: post.createdAt,
           deleted: false,
@@ -117,7 +121,8 @@ export async function GET(request: NextRequest) {
             description: post.description,
             tagline: post.tagline,
             url: post.url,
-            hasAi: postAiResults.get(post.id) ?? false,
+            hasAi: postAiResults.get(post.id)?.isAiRelated ?? false,
+            reasoning: postAiResults.get(post.id)?.reasoning ?? null,
             thumbnailUrl: post.thumbnail.url,
             media: post.media,
             deleted: false,

--- a/apps/web/src/app/lib/ai-analyzer.ts
+++ b/apps/web/src/app/lib/ai-analyzer.ts
@@ -135,8 +135,8 @@ export const analyzePosts = async (
     description: string;
     topics: { name: string; description: string }[];
   }[],
-): Promise<Map<string, boolean>> => {
-  const results = new Map<string, boolean>();
+): Promise<Map<string, AnalysisResult>> => {
+  const results = new Map<string, AnalysisResult>();
   let totalMismatches = 0;
   let totalRequests = 0;
 
@@ -186,7 +186,10 @@ export const analyzePosts = async (
       );
       // Default all posts in this chunk to true (AI slop)
       for (const post of chunkPosts) {
-        results.set(post.id, true);
+        results.set(post.id, {
+          isAiRelated: true,
+          reasoning: "Analysis unavailable: the AI request failed.",
+        });
       }
       continue; // Skip to next chunk
     }
@@ -199,7 +202,10 @@ export const analyzePosts = async (
         `Chunk ${Math.floor(i / CHUNK_SIZE) + 1}: Failed to parse response, defaulting all posts to AI slop`,
       );
       for (const post of chunkPosts) {
-        results.set(post.id, true);
+        results.set(post.id, {
+          isAiRelated: true,
+          reasoning: "Analysis unavailable: the AI response could not be parsed.",
+        });
       }
       continue; // Skip to next chunk
     }
@@ -220,15 +226,16 @@ export const analyzePosts = async (
 
       // If result is missing, default to true (AI slop)
       const isAiRelated = result?.isAiRelated ?? true;
+      const reasoning = result?.reasoning ?? "No reasoning provided (defaulted to AI slop)";
 
       console.log({
         post: post.name,
         isAiRelated,
-        reasoning: result?.reasoning ?? "No reasoning provided (defaulted to AI slop)",
+        reasoning,
       });
 
       // Use post ID as the cache key
-      results.set(post.id, isAiRelated);
+      results.set(post.id, { isAiRelated, reasoning });
     }
   }
 
@@ -238,7 +245,7 @@ export const analyzePosts = async (
     );
   }
 
-  results.set(PRODUCT_HUNT_ID, false);
+  results.set(PRODUCT_HUNT_ID, { isAiRelated: false, reasoning: "Product Hunt itself" });
 
   console.log(`Total Gemini API requests made: ${totalRequests}`);
 

--- a/apps/web/src/app/lib/data.ts
+++ b/apps/web/src/app/lib/data.ts
@@ -129,6 +129,7 @@ export const convertPostToProductPost = (post: Post): ProductPost => {
     createdAt: new Date(post.createdAt),
     url: post.url,
     hasAi: false,
+    reasoning: null,
     name: post.name,
     tagline: post.tagline,
     media: post.media,

--- a/apps/web/src/app/projects.ts
+++ b/apps/web/src/app/projects.ts
@@ -5,7 +5,7 @@ let projectCounter = 1;
 export function createProject(
   data: Omit<
     ProductPost,
-    "id" | "topics" | "createdAt" | "votesCount" | "deleted" | "hasAi" | "media"
+    "id" | "topics" | "createdAt" | "votesCount" | "deleted" | "hasAi" | "reasoning" | "media"
   > & {
     topics: string[];
   },
@@ -18,6 +18,7 @@ export function createProject(
   return {
     id: projectId,
     hasAi: false,
+    reasoning: null,
     deleted: false,
     votesCount: 0,
     createdAt: new Date(),

--- a/apps/web/src/app/view/[slug]/page.client.tsx
+++ b/apps/web/src/app/view/[slug]/page.client.tsx
@@ -47,9 +47,23 @@ export default function ClientPage({ project }: ClientPageProps) {
                 />
               </svg>
               {project.hasAi && (
-                <h2 className="text-lg font-bold text-red-700 dark:text-red-400">
-                  This product is some form of AI slop and you should probably not use it
-                </h2>
+                <div>
+                  <h2 className="text-lg font-bold text-red-700 dark:text-red-400">
+                    Flagged as AI-related
+                  </h2>
+                  {project.reasoning ? (
+                    <p className="text-sm text-red-700/80 dark:text-red-400/80">
+                      <span className="font-semibold">Why the model flagged it:</span>{" "}
+                      {project.reasoning}
+                    </p>
+                  ) : (
+                    <p className="text-sm text-red-700/80 dark:text-red-400/80">
+                      The classifier detected AI/ML terms in this listing, so it is filtered from
+                      the no-slop feed — an automated match, not a quality judgment about the
+                      product.
+                    </p>
+                  )}
+                </div>
               )}
             </div>
           </div>


### PR DESCRIPTION
Fixes #132.

## Problem

The `/view` page renders a quality verdict — *"This product is some form of AI slop and you should probably not use it"* — whenever `hasAi` is true. But the classifier ([`prompt.txt`](https://github.com/Hacksore/oghunt/blob/main/apps/web/src/app/lib/prompt.txt)) only ever sets `isAiRelated` on a keyword match; it never assesses quality. The `reasoning` it produces (which terms it matched) was logged at ingest and then discarded. So the UI asserted a judgment the model never made — a false positive on legitimate AI products.

## Change

Surface the model's actual reasoning instead of the verdict (option 1 from the issue; no reports/appeal flow, per your comment):

- **`schema.prisma`** — add `reasoning String?` to `Post` (nullable; existing rows unaffected).
- **`ai-analyzer.ts`** — `analyzePosts` now returns `{ isAiRelated, reasoning }`; the API-error and parse-error fallbacks write an honest *"Analysis unavailable…"* reason instead of silently implying slop.
- **`ingest-posts/route.ts`** — persist both `hasAi` and `reasoning`.
- **`view/[slug]/page.client.tsx`** — heading becomes **"Flagged as AI-related"** followed by the model's reasoning, with a neutral fallback for rows analyzed before this field existed.

## Deploy note

Needs `pnpm db:push` (nullable column, non-destructive). Old rows show the fallback copy until re-ingested; new launches get the reasoning immediately.

## Verification

- `tsc --noEmit`: clean
- `biome check src`: clean

(`next build` not run here — it evaluates `@/app/env` at build and needs `DATABASE_URL`/`GEMINI_API_KEY`; types and lint are covered above.)
