### PR TITLE
Add Cursor Cloud dev environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a pnpm + Turborepo monorepo (`oghunt`). The only deployable app is `apps/web`
+(Next.js 15 / React 19, Prisma + PostgreSQL). `packages/email` is a `jsx-email` preview tool
+and `packages/typescript-config` is build-time only. Standard commands live in the root
+`package.json`, `apps/web/package.json`, and `README.md` — reference those instead of duplicating.
+
+### Services
+- **PostgreSQL** (required): runs via `docker compose up -d` (container `oghunt-db`, port 5432,
+  user/pass `dev`/`dev`, db `oghunt`). The Docker daemon does not auto-start in this environment —
+  run `sudo service docker start` first if `docker ps` fails to connect.
+- **Next.js web app** (required): `pnpm dev` serves it on port 3000. Note `pnpm dev` runs the
+  whole turbo `dev` pipeline, so it ALSO starts the `email` preview server (port ~55420). That is
+  expected; the product under test is on port 3000.
+
+### Environment files (non-obvious)
+- `apps/web/src/app/env.ts` calls `envSchema.parse(process.env)` at import time, so the app
+  **crashes on boot** unless `PH_API_KEY`, `DATABASE_URL`, `CRON_SECRET`, and `GEMINI_API_KEY`
+  are all set (non-empty). Use placeholder strings for `PH_API_KEY`/`GEMINI_API_KEY` when not
+  doing live ingestion.
+- `prisma/schema.prisma` also requires `DIRECT_URL` to be set (point it at the same local DB as
+  `DATABASE_URL`), or `prisma db push`/`generate` fail validation.
+- Env files (`.env` at repo root and `apps/web/.env`) are gitignored. The root `.env` is consumed
+  by the `dotenv -e .env` db scripts; Next.js loads `apps/web/.env`. Both should contain the same
+  values for local dev.
+
+### Seeding data without API keys
+- `pnpm db:push` (once) syncs the schema, then `pnpm db:seed` inserts 4000 fake posts via faker —
+  no Product Hunt / Gemini keys needed. This is the fastest way to get a populated UI.
+- Live ingestion instead uses `GET /api/ingest-posts` with header `Authorization: Bearer <CRON_SECRET>`
+  and requires real `PH_API_KEY` + `GEMINI_API_KEY`.
+
+### Lint / build
+- Lint/format is Biome: `pnpm check` (root) → `biome check src` in `apps/web`.
+- `pnpm build` builds the web app; the `email#build` "no output files found" turbo warning is benign.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for the `oghunt` monorepo and documents non-obvious startup caveats for future cloud agents in `AGENTS.md`.

No application code was changed — this only adds `AGENTS.md`.

## What was done

- Installed Docker (engine + compose) to run the PostgreSQL container, and configured the daemon for the nested VM (fuse-overlayfs, legacy iptables).
- Created local env files (`.env` + `apps/web/.env`, gitignored) with the required vars. Discovered `DIRECT_URL` is also required by `prisma/schema.prisma` and that `env.ts` parses env at import time (app crashes on boot without all 4 keys).
- Installed dependencies (`pnpm install`), pushed the Prisma schema (`pnpm db:push`), and seeded 4000 fake posts (`pnpm db:seed`) — no external API keys required.
- Verified lint, build, and the dev server, then exercised the core flow (home → list → post detail) in the browser.

## Verification

| Service | Lint | Build | Run |
|---|---|---|---|
| `apps/web` (Next.js) | `pnpm check` ✅ | `pnpm build` ✅ | `pnpm dev` ✅ (port 3000) |

Walkthrough of the running app browsing seeded launches:

[oghunt_app_walkthrough.mp4](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foghunt_app_walkthrough.mp4)

[oghunt home page with launch cards](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foghunt_home.webp)
[oghunt single post detail view](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foghunt_post_detail.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

