### PR TITLE
Fix Supabase Disk IO bottleneck: drop unused `deleted` column + index hot queries

### DIFF
--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -35,18 +35,15 @@ model Post {
   votesCount   Int         @default(0)
   hasAi        Boolean     @default(false)
   media        Json?       @default("[]")
-  /// if the post is deleted, it means it was deleted by the user or product hunt team
-  deleted      Boolean     @default(false)
   topics       TopicPost[]
 
-  // The hot read path (home, /list, /ai, /api/list, /api/stats) filters by
-  // deleted + hasAi over a createdAt day-range. Without these indexes Postgres
-  // sequentially scans the entire table on every request, which is the main
-  // driver of Disk IO budget consumption.
-  @@index([deleted, hasAi, createdAt])
-  // Serves the sitemap (deleted = false, ordered by createdAt) and any
-  // createdAt range query that does not constrain hasAi.
-  @@index([deleted, createdAt])
+  // The hot read path (home, /list, /ai) filters by hasAi over a createdAt
+  // day-range. Without an index Postgres sequentially scans the entire table on
+  // every request, which is the main driver of Disk IO budget consumption.
+  @@index([hasAi, createdAt])
+  // Serves the createdAt-range/ordered reads that do not constrain hasAi
+  // (/api/list, /api/stats, sitemap).
+  @@index([createdAt])
 }
 
 model TopicPost {

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -38,6 +38,15 @@ model Post {
   /// if the post is deleted, it means it was deleted by the user or product hunt team
   deleted      Boolean     @default(false)
   topics       TopicPost[]
+
+  // The hot read path (home, /list, /ai, /api/list, /api/stats) filters by
+  // deleted + hasAi over a createdAt day-range. Without these indexes Postgres
+  // sequentially scans the entire table on every request, which is the main
+  // driver of Disk IO budget consumption.
+  @@index([deleted, hasAi, createdAt])
+  // Serves the sitemap (deleted = false, ordered by createdAt) and any
+  // createdAt range query that does not constrain hasAi.
+  @@index([deleted, createdAt])
 }
 
 model TopicPost {
@@ -47,6 +56,10 @@ model TopicPost {
   Topic   Topic  @relation(fields: [topicId], references: [id], onDelete: Cascade)
 
   @@id([topicId, postId])
+  // The composite primary key is keyed on topicId first, so resolving a post's
+  // topics (Prisma `include: { topics }`) cannot use it and falls back to a
+  // sequential scan. This index makes those lookups index-backed.
+  @@index([postId])
 }
 
 model Metric {
@@ -56,6 +69,10 @@ model Metric {
   totalVotes           Int
   aiProjectsPercentage Float
   aiVotesPercentage    Float
+
+  // The /slop page (force-dynamic) filters by a timestamp window and /api/stats/time
+  // orders by timestamp; index it so those reads don't scan the whole table.
+  @@index([timestamp])
 }
 
 enum EmailSource {

--- a/apps/web/scripts/seed-db.ts
+++ b/apps/web/scripts/seed-db.ts
@@ -7,7 +7,6 @@ const createFakePost = (_: unknown, id: number): Prisma.PostCreateManyInput => {
   return {
     createdAt: new Date(),
     name: faker.lorem.sentence(),
-    deleted: false,
     description: faker.lorem.paragraph(),
     hasAi: false,
     media: Array.from({ length: 10 }, () => ({

--- a/apps/web/src/app/api/ingest-posts/route.ts
+++ b/apps/web/src/app/api/ingest-posts/route.ts
@@ -4,7 +4,6 @@ import env from "@/app/env";
 import db from "../../db";
 import { analyzePosts } from "../../lib/ai-analyzer";
 import { convertPostToProductPost, getAllPost, getAllPostsVotesMoarBetter } from "../../lib/data";
-import { PRODUCT_HUNT_NAME } from "../../utils/string";
 
 export const dynamic = "force-dynamic";
 
@@ -91,7 +90,6 @@ export async function GET(request: NextRequest) {
           hasAi: postAiResults.get(post.id) ?? false,
           thumbnailUrl: post.thumbnail.url,
           createdAt: post.createdAt,
-          deleted: false,
         })),
       ),
       skipDuplicates: true,
@@ -120,7 +118,6 @@ export async function GET(request: NextRequest) {
             hasAi: postAiResults.get(post.id) ?? false,
             thumbnailUrl: post.thumbnail.url,
             media: post.media,
-            deleted: false,
           },
         }),
       ),
@@ -139,21 +136,6 @@ export async function GET(request: NextRequest) {
   await db.topicPost.createMany({
     data: topicPosts,
     skipDuplicates: true,
-  });
-
-  await db.post.updateMany({
-    where: {
-      name: {
-        not: PRODUCT_HUNT_NAME,
-      },
-      id: {
-        notIn: posts.map((post) => post.id),
-      },
-      deleted: false,
-    },
-    data: {
-      deleted: true,
-    },
   });
 
   revalidatePath("/api/list");

--- a/apps/web/src/app/lib/data.ts
+++ b/apps/web/src/app/lib/data.ts
@@ -124,7 +124,6 @@ export async function getAllPostsVotesMoarBetter(
 
 export const convertPostToProductPost = (post: Post): ProductPost => {
   return {
-    deleted: false,
     id: post.id,
     createdAt: new Date(post.createdAt),
     url: post.url,

--- a/apps/web/src/app/lib/launches.ts
+++ b/apps/web/src/app/lib/launches.ts
@@ -16,7 +16,6 @@ export async function getYesterdaysLaunches() {
         gte: new Date(startOfDayUTC),
         lt: new Date(endOfDayUTC),
       },
-      deleted: true,
       hasAi: false,
     },
     orderBy: {
@@ -42,7 +41,6 @@ export async function getTodaysLaunches(hasAi?: boolean) {
         gte: startOfDayUTC,
         lt: endOfDayUTC,
       },
-      deleted: false,
       ...(hasAi !== undefined && { hasAi }),
     },
     include: {
@@ -77,7 +75,6 @@ export async function getTodaysLaunchesPaginated({
         gte: startOfDayUTC,
         lt: endOfDayUTC,
       },
-      deleted: false,
       ...(hasAi !== undefined && { hasAi }),
     },
   });
@@ -88,7 +85,6 @@ export async function getTodaysLaunchesPaginated({
         gte: startOfDayUTC,
         lt: endOfDayUTC,
       },
-      deleted: false,
       ...(hasAi !== undefined && { hasAi }),
     },
     include: {

--- a/apps/web/src/app/projects.ts
+++ b/apps/web/src/app/projects.ts
@@ -3,10 +3,7 @@ import type { ProductPost } from "./types";
 let projectCounter = 1;
 
 export function createProject(
-  data: Omit<
-    ProductPost,
-    "id" | "topics" | "createdAt" | "votesCount" | "deleted" | "hasAi" | "media"
-  > & {
+  data: Omit<ProductPost, "id" | "topics" | "createdAt" | "votesCount" | "hasAi" | "media"> & {
     topics: string[];
   },
 ): ProductPost {
@@ -18,7 +15,6 @@ export function createProject(
   return {
     id: projectId,
     hasAi: false,
-    deleted: false,
     votesCount: 0,
     createdAt: new Date(),
     topics: topicNames.map((topicName, index) => ({

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -15,11 +15,7 @@ function escapeXml(unsafe: string): string {
 // Cached function to get total post count (6 hours cache)
 const getCachedPostCount = unstable_cache(
   async () => {
-    return await db.post.count({
-      where: {
-        deleted: false,
-      },
-    });
+    return await db.post.count();
   },
   ["post-count"],
   {
@@ -33,9 +29,6 @@ const getCachedPosts = unstable_cache(
     const skip = chunkId * chunkSize;
 
     return await db.post.findMany({
-      where: {
-        deleted: false,
-      },
       select: {
         id: true,
         name: true,
@@ -56,7 +49,7 @@ const getCachedPosts = unstable_cache(
 
 export async function generateSitemaps() {
   try {
-    // Get total count of non-deleted posts with caching
+    // Get total count of posts with caching
     const totalPosts = await getCachedPostCount();
 
     // Calculate number of sitemap chunks needed (50k per chunk for better performance)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Diagnosis

The Disk IO budget alerts come from the `Post` table being **sequentially scanned in full on nearly every page view**.

The home page, `/list`, and `/ai` are all `export const dynamic = "force-dynamic"` and call `getTodaysLaunches` / `getTodaysLaunchesPaginated` (`apps/web/src/app/lib/launches.ts`) on every request. Those queries filter `Post` over a `createdAt` day-range; `/api/list`, `/api/stats`, `/slop`, and `sitemap.ts` hit the same table the same way. `Post` had **no indexes except its primary key**, so every request read the whole table to return a few hundred rows.

## Two changes

### 1. Drop the `deleted` column (it was vestigial)
`deleted` dates back to when AI filtering ran every 15 minutes and removed posts mid-day. Now ingestion runs once a day, and the **only** writer that set it to `true` was the daily `updateMany` in `ingest-posts` that flipped every post *not in today's fetch* to `deleted=true` — which is already implied by the `createdAt` day-range filter every read path uses. It was also silently limiting the **sitemap** to today's posts only (`deleted=false`).

So this PR:
- removes the `deleted` column from `Post`,
- removes the daily `updateMany` (a large daily write — also IO) and the `deleted` writes in `ingest-posts`,
- removes the now-redundant `deleted` filters from the launch queries,
- lets the sitemap include **all** posts (fixes the latent SEO bug).

A soft-delete flag can be reintroduced if/when we actually want soft deletes.

### 2. Index the hot read paths
- `Post @@index([hasAi, createdAt])` — the launch queries (filter `hasAi` + `createdAt` range).
- `Post @@index([createdAt])` — `createdAt`-range/ordered reads without a `hasAi` filter (`/api/list`, `/api/stats`, sitemap).
- `TopicPost @@index([postId])` — the composite PK is keyed on `topicId` first, so `include: { topics }` couldn't use it.
- `Metric @@index([timestamp])` — `/slop` window + `/api/stats/time` ordering.

`votesCount` is intentionally left out of the indexes so the every‑15‑minutes `update-vote-count` cron doesn't pay index write amplification.

## Evidence

Reproduced on Postgres with a production-shaped dataset (~154k posts). `EXPLAIN (ANALYZE, BUFFERS)` — `shared` buffers = 8KB pages touched (≈ disk reads when uncached):

| Hot query | Before | After | Page reads ↓ |
|---|---|---|---|
| Today's launches (`hasAi=false`) | Parallel **Seq Scan**, 4400 pages, 11ms | **Index Scan** `[hasAi, createdAt]`, 206 pages, 0.17ms | ~21× |
| Today's count | Parallel **Seq Scan**, 4400 pages, 9.5ms | **Index Only Scan**, 5 pages, 0.05ms | ~880× |
| Today's launches (no `hasAi` filter) | Parallel **Seq Scan**, 4400 pages, 8.9ms | **Bitmap Index Scan** `[createdAt]`, 14 pages, 0.17ms | ~310× |
| Sitemap | **Seq Scan** + temp-file sort, 26.7ms | **Index Scan Backward** `[createdAt]` (now returns *all* posts) | sort spill removed |

Full before/after `EXPLAIN ANALYZE` output attached.

[disk_io_explain_no_deleted.log](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdisk_io_explain_no_deleted.log)

## App still works end-to-end

After applying the schema change to a seeded DB, home → `/list` → detail all render real content and the AI filter works (`AI • 1.2K` / `2.8K • No AI`):

[oghunt_after_removing_deleted.mp4](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foghunt_after_removing_deleted.mp4)

[Home page after removing deleted](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_deleted_home.webp)
[Post detail after removing deleted](https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_deleted_detail.webp)

## Applying in production (important)

This repo uses `prisma db push`. Dropping the column + creating indexes with a plain `db push` **locks the table** and needs `--accept-data-loss`. On the large production `Post` table, do it manually instead — build indexes concurrently and drop the column in a quick separate statement:

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS "Post_hasAi_createdAt_idx" ON "Post" ("hasAi", "createdAt");
CREATE INDEX CONCURRENTLY IF NOT EXISTS "Post_createdAt_idx"       ON "Post" ("createdAt");
CREATE INDEX CONCURRENTLY IF NOT EXISTS "TopicPost_postId_idx"     ON "TopicPost" ("postId");
CREATE INDEX CONCURRENTLY IF NOT EXISTS "Metric_timestamp_idx"     ON "Metric" ("timestamp");
ALTER TABLE "Post" DROP COLUMN IF EXISTS "deleted";
```

## Verification
- ✅ `pnpm db:push` applied the drop + 4 indexes (confirmed via `pg_indexes`).
- ✅ `pnpm db:generate`, `pnpm check`, `pnpm build` all pass (build now emits sitemap chunks 0–3, i.e. it includes all posts).
- ✅ App serves real content across `/`, `/list`, `/ai`, `/api/list`, `/slop` (see demo).
- ✅ `EXPLAIN (ANALYZE, BUFFERS)` before/after confirms seq scan → index scan.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-638599d3-1c85-4ff2-908c-22ee03ca9a3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

